### PR TITLE
Extract the used Relays to the Env Configuration

### DIFF
--- a/.env
+++ b/.env
@@ -13,3 +13,7 @@ ESCROW_NPUB=npub1hcsc4r3xc9ygnefp4eqyan9r46tjvd3w0dxk2hgydc9k6m5xd3jq2hkjqp
 # Mint URL
 MINT_URL=http://0.0.0.0:3338
 #MINT_URL=https://mint.minibits.cash/Bitcoin
+
+# Nostr relays (comma separated)
+NOSTR_RELAYS="ws://localhost:4736"
+# NOSTR_RELAYS="wss://relay.damus.io, wss://relay.primal.net, wss://relay.nostr.band, wss://ftp.halifax.rwth-aachen.de/nostr, wss://nostr.mom, wss://relay.nostrplebs.com"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
  "anyhow",
  "cashu_escrow_common",
  "cdk",
- "dotenv",
+ "dotenvy",
  "env_logger",
  "log",
  "nostr-sdk",
@@ -573,7 +573,7 @@ dependencies = [
  "cashu_escrow_client",
  "cashu_escrow_common",
  "cdk",
- "dotenv",
+ "dotenvy",
  "env_logger",
  "log",
  "nostr-sdk",
@@ -691,10 +691,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ nostr-sdk = { version = "0.34", features = [] }
 cdk = "0.4.0"
 anyhow = "1"
 log = "0.4"
-dotenv = "0.15"
+dotenvy = "0.15"
 tokio = "1.38"
 serde_json = "1"
 serde = "*"

--- a/client_app/Cargo.toml
+++ b/client_app/Cargo.toml
@@ -9,7 +9,7 @@ nostr-sdk = { workspace = true }
 cdk = { workspace = true }
 log = { workspace = true }
 anyhow = { workspace = true}
-dotenv = { workspace = true }
+dotenvy = { workspace = true }
 tokio = { workspace = true }
 env_logger = { workspace = true }
 

--- a/client_app/src/main.rs
+++ b/client_app/src/main.rs
@@ -9,7 +9,7 @@ use cashu_escrow_common::nostr::NostrClient;
 use cdk::amount::{Amount, SplitTarget};
 use cli::trade_contract::FromClientCliInput;
 use cli::ClientCliInput;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 

--- a/client_app/src/main.rs
+++ b/client_app/src/main.rs
@@ -41,7 +41,11 @@ async fn main() -> anyhow::Result<()> {
 
     let escrow_contract =
         TradeContract::from_client_cli_input(&cli_input, escrow_wallet.trade_pubkey.clone())?;
-    let nostr_client = NostrClient::new(cli_input.trader_nostr_keys).await?;
+    let relays = env::var("NOSTR_RELAYS")?
+        .split(',')
+        .map(String::from)
+        .collect();
+    let nostr_client = NostrClient::new(cli_input.trader_nostr_keys, relays).await?;
 
     InitEscrowClient::new(nostr_client, escrow_wallet, escrow_contract, cli_input.mode)
         .register_trade()

--- a/common/src/nostr/mod.rs
+++ b/common/src/nostr/mod.rs
@@ -4,7 +4,7 @@ mod tests;
 use std::time::Duration;
 
 use crate::model::EscrowRegistration;
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 use nostr_sdk::prelude::*;
@@ -28,20 +28,16 @@ pub struct NostrClient {
 const CACHE_SIZE: usize = 10;
 
 impl NostrClient {
-    pub async fn new(keys: Keys) -> anyhow::Result<Self> {
+    pub async fn new(keys: Keys, relays: Vec<String>) -> anyhow::Result<Self> {
         let client = Client::new(&keys);
 
-        //client.add_relay("wss://relay.damus.io").await?;
-        //client.add_relay("wss://relay.primal.net").await?;
-        // client.add_relay("wss://relay.nostr.band").await?;
-        /* client
-        .add_relay("wss://ftp.halifax.rwth-aachen.de/nostr")
-        .await?; */
-        //client.add_relay("wss://nostr.mom").await?;
-        //client.add_relay("wss://relay.nostrplebs.com").await?; (having errors)
-        client.add_relay("ws://localhost:4736").await?;
-
         // Connect to relays
+        for relay in &relays {
+            client
+                .add_relay(relay)
+                .await
+                .context(format!("Error adding nostr relay: {}", relay))?;
+        }
         client.connect().await;
 
         let (_subscription_id, notifications_receiver) = init_subscription(&keys, &client).await?;

--- a/common/src/nostr/tests.rs
+++ b/common/src/nostr/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 
 /// Receive a message when only one mesage was sent by the escrow.
 #[tokio::test]
@@ -103,5 +103,6 @@ struct TestMessage2(usize);
 
 async fn create_nostr_client() -> NostrClient {
     let keys = Keys::generate();
-    NostrClient::new(keys).await.unwrap()
+    let relays: Vec<String> = vec!["ws://localhost:4736".to_string()];
+    NostrClient::new(keys, relays).await.unwrap()
 }

--- a/common/src/nostr/tests.rs
+++ b/common/src/nostr/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use serde::{Deserialize, Serialize};
-use std::{str::FromStr, time::Duration};
+use std::time::Duration;
 
 /// Receive a message when only one mesage was sent by the escrow.
 #[tokio::test]

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -10,7 +10,7 @@ nostr-sdk = { workspace = true }
 cdk = { workspace = true }
 log = { workspace = true }
 anyhow = { workspace = true }
-dotenv = { workspace = true }
+dotenvy = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -18,7 +18,11 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let keys = Keys::from_str(&env::var("ESCROW_NSEC")?)?;
-    let nostr_client = NostrClient::new(keys).await?;
+    let relays = env::var("NOSTR_RELAYS")?
+        .split(',')
+        .map(String::from)
+        .collect();
+    let nostr_client = NostrClient::new(keys, relays).await?;
     info!(
         "Coordinator npub: {}",
         nostr_client.public_key().to_bech32()?

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -3,7 +3,7 @@ mod escrow_coordinator;
 use std::{env, str::FromStr};
 
 use cashu_escrow_common::nostr::NostrClient;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use escrow_coordinator::EscrowCoordinator;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};


### PR DESCRIPTION
Solves https://github.com/f321x/cashu-escrow-kit/issues/22
Loads a CSV string NOSTR_RELAYS from the .env file and passes it to the NostrClient as parsed Vec<String> which then connects to the relays. Enables quick changes to the used relay setup without code changes.