### PR TITLE
WIP: Using rust-nostr LocalRelay for testing

### DIFF
--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { workspace = true }
 rand = { workspace = true }
 sha2 = { workspace = true }
 env_logger = { workspace = true }
+nostr-relay-builder = { workspace = true }
 
 cashu_escrow_common = { path = "../common" }
 

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -1,13 +1,14 @@
 mod escrow_coordinator;
 
-use std::{env, str::FromStr};
-
+use anyhow::Context;
 use cashu_escrow_common::nostr::NostrClient;
 use dotenvy::dotenv;
 use escrow_coordinator::EscrowCoordinator;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
+use nostr_relay_builder::{LocalRelay, RelayBuilder};
 use nostr_sdk::{Keys, ToBech32};
+use std::{env, str::FromStr};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -16,12 +17,19 @@ async fn main() -> anyhow::Result<()> {
         .filter_module("cashu_escrow_coordinator", log::LevelFilter::Trace) // level for the application itself
         .filter_level(log::LevelFilter::Info) // level for imported crates
         .init();
+    let local_relay: LocalRelay; // has to stay in scope to keep the relay running
 
     let keys = Keys::from_str(&env::var("ESCROW_NSEC")?)?;
-    let relays = env::var("NOSTR_RELAYS")?
+    let mut relays: Vec<String> = env::var("NOSTR_RELAYS")?
         .split(',')
+        .filter(|s| !s.is_empty())
         .map(String::from)
         .collect();
+    if relays.is_empty() {
+        local_relay = run_local_relay().await?;
+        relays = vec![local_relay.url()]
+    };
+
     let nostr_client = NostrClient::new(keys, relays).await?;
     info!(
         "Coordinator npub: {}",
@@ -29,4 +37,17 @@ async fn main() -> anyhow::Result<()> {
     );
     info!("Starting service and waiting for trades...");
     return EscrowCoordinator::new(nostr_client)?.run().await;
+}
+
+/// Starts a in-memory mock relay for testing purposes
+async fn run_local_relay() -> anyhow::Result<LocalRelay> {
+    let builder = RelayBuilder::default();
+    let local_relay = LocalRelay::run(builder)
+        .await
+        .context("Failed to start local relay")?;
+    warn!(
+        "Running in-memory relay at {}. Only for testing purposes",
+        local_relay.url()
+    );
+    Ok(local_relay)
 }


### PR DESCRIPTION
Some experimentation with the rust-nostr [nostr-relay-builder](https://github.com/rust-nostr/nostr/tree/master/crates/nostr-relay-builder) crate. But it seems like there are still problems as i constantly keep getting 
``` [2024-10-03T22:59:22Z WARN  nostr_relay_builder::local::internal] WebSocket protocol error: No "Connection: upgrade" header ``` when trying to connect and connections close after a couple of seconds.
The relay is constructed from the default builder like this:
```rust
    let builder = RelayBuilder::default();
    let local_relay = LocalRelay::run(builder)
        .await
        .context("Failed to start local relay")?;
```
The nostr-relay-builder is explicitly stated as alpha version and the crates.io version is different from the repository, so its probably best to let it mature a bit first.